### PR TITLE
Rapp discovery speedup

### DIFF
--- a/rocon_app_manager/package.xml
+++ b/rocon_app_manager/package.xml
@@ -16,6 +16,7 @@
   <buildtool_depend>catkin</buildtool_depend>
 
   <run_depend>roslib</run_depend>
+  <run_depend>rospkg</run_depend>
   <run_depend>rospy</run_depend>
   <run_depend>rosmaster</run_depend>
   <run_depend>rocon_apps</run_depend>

--- a/rocon_app_manager/src/rocon_app_manager/rapp.py
+++ b/rocon_app_manager/src/rocon_app_manager/rapp.py
@@ -60,8 +60,10 @@ class Rapp(object):
     path = None
     data = {}
 
-    def __init__(self, resource_name):
+    def __init__(self, resource_name, rospack=None):
         '''
+          @param rospack : a cache to help with repeat calls (optional)
+          @type rospkg.RosPack
           @param resource_name : a package/name pair for this rapp
           @type str/str
         '''
@@ -69,7 +71,7 @@ class Rapp(object):
         self._connections = {}
         for connection_type in ['publishers', 'subscribers', 'services', 'action_clients', 'action_servers']:
             self._connections[connection_type] = []
-        self._load_from_resource_name(resource_name)
+        self._load_from_resource_name(resource_name, rospack=rospack)
 
     def __repr__(self):
         string = ""
@@ -77,26 +79,30 @@ class Rapp(object):
             string += d + " : " + str(self.data[d]) + "\n"
         return string
 
-    def _load_from_resource_name(self, name):
+    def _load_from_resource_name(self, name, rospack=None):
         '''
           Loads from a ros resource name consisting of a package/app pair.
 
           @param name : unique identifier for the app, e.g. rocon_apps/chirp.
           @type str
+          @param rospack : a cache to help with repeat calls (optional)
+          @type rospkg.RosPack
 
           @raise InvalidRappException if the app definition was for some reason invalid.
         '''
         if not name:
             raise InvalidRappException("app name was invalid [%s]" % name)
-        self.filename = utils.find_resource(name + '.rapp')
-        self._load_from_app_file(self.filename, name)
+        self.filename = utils.find_resource(name + '.rapp', rospack=rospack)
+        self._load_from_app_file(self.filename, name, rospack=rospack)
 
-    def _load_from_app_file(self, path, app_name):
+    def _load_from_app_file(self, path, app_name, rospack=None):
         '''
           Open and read directly from the app definition file (.rapp file).
 
           @param path : full path to the .rapp file
           @param app_name : unique name for the app (comes from the .rapp filename)
+          @param rospack : a cache to help with repeat calls (optional)
+          @type rospkg.RosPack
         '''
         rospy.loginfo("App Manager : loading app '%s'" % app_name)  # str(path)
         self.filename = path
@@ -113,14 +119,14 @@ class Rapp(object):
             data['display_name'] = app_data.get('display', app_name)
             data['description'] = app_data.get('description', '')
             data['platform'] = app_data['platform']
-            data['launch'] = self._find_rapp_resource(app_data['launch'], 'launch', app_name)
-            data['interface'] = self._load_interface(self._find_rapp_resource(app_data['interface'], 'interface', app_name))
+            data['launch'] = self._find_rapp_resource(app_data['launch'], 'launch', app_name, rospack=rospack)
+            data['interface'] = self._load_interface(self._find_rapp_resource(app_data['interface'], 'interface', app_name, rospack=rospack))
             data['pairing_clients'] = []
             data['pairing_clients'] = self._load_pairing_clients(app_data, path)
             if 'icon' not in app_data:
                 data['icon'] = None
             else:
-                data['icon'] = self._find_rapp_resource(app_data['icon'], 'icon', app_name)
+                data['icon'] = self._find_rapp_resource(app_data['icon'], 'icon', app_name, rospack=rospack)
             data['status'] = 'Ready'
 
         self.data = data
@@ -142,7 +148,7 @@ class Rapp(object):
                                        dict_to_KeyValue(pairing_client.app_data)))
         return a
 
-    def _find_rapp_resource(self, resource, log, app_name="Unknown"):
+    def _find_rapp_resource(self, resource, log, app_name="Unknown", rospack=None):
         '''
           A simple wrapper around utils.find_resource to locate rapp resources.
 
@@ -153,10 +159,12 @@ class Rapp(object):
           @param name : app name, also only used for logging purposes
           @return full path to the resource
           @type str
+          @param rospack : a cache to help with repeat calls (optional)
+          @type rospkg.RosPack
           @raise AppException: if resource does not exist or something else went wrong.
         '''
         try:
-            path_to_resource = utils.find_resource(resource)
+            path_to_resource = utils.find_resource(resource, rospack=rospack)
             if not os.path.exists(path_to_resource):
                 raise AppException("invalid appfile [%s]: %s file does not exist." % (app_name, log))
             return path_to_resource

--- a/rocon_app_manager/src/rocon_app_manager/rapp_list.py
+++ b/rocon_app_manager/src/rocon_app_manager/rapp_list.py
@@ -22,6 +22,7 @@
 import os
 import rospy
 import yaml
+import rospkg
 from .rapp import Rapp
 
 ##############################################################################
@@ -59,8 +60,9 @@ class RappListFile(object):
             apps_yaml = yaml.load(f)
             if not 'apps' in apps_yaml:
                 rospy.logerr("App Manager : apps file [%s] is missing required key [%s]" % (self.filename, 'apps'))
+            rospack = rospkg.RosPack()
             for app_resource_name in apps_yaml['apps']:
-                app = Rapp(app_resource_name)
+                app = Rapp(app_resource_name, rospack)
                 available_apps.append(app)
         self.available_apps = available_apps
 

--- a/rocon_app_manager/src/rocon_app_manager/utils.py
+++ b/rocon_app_manager/src/rocon_app_manager/utils.py
@@ -36,13 +36,15 @@ class PlatformTuple(object):
         self.robot = platform_tuple_list[2]
 
 
-def find_resource(resource):
+def find_resource(resource, rospack=None):
     '''
       Ros style resource finder. Need to depracate this in favour
       of rocon_utilities.ros_utilities.find_resource_from_string
 
       @param resource is a ros resource (package/name)
       @type str
+      @param rospack a cache to help with repeat calls (optional)
+      @type rospkg.RosPack
       @return full path to the resource
       @type str
       @raise NotFoundException: if resource does not exist.
@@ -50,7 +52,7 @@ def find_resource(resource):
     p, a = roslib.names.package_resource_name(resource)
     if not p:
         raise NotFoundException("resource is missing package name [%s]" % (resource))
-    matches = roslib.packages.find_resource(p, a)
+    matches = roslib.packages.find_resource(p, a, rospack=rospack)
     if len(matches) == 1:
         return matches[0]
     elif not matches:


### PR DESCRIPTION
This addresses #71.

It uses a rospack cache initiated at the point we start reading a rapp list file (could actually be sent back one step further for all rapp list files) to speedup package resource discovery. Previously it had to crawl and make the package tree every time it tried to find a resource.

This gives a 2-3x speedup.
