### PR TITLE
Use concert whitelists instead of forcing the name.

### DIFF
--- a/rocon_app_manager/launch/concert_client.launch
+++ b/rocon_app_manager/launch/concert_client.launch
@@ -5,7 +5,7 @@
  -->
 <launch>
   <!-- ******************************* Arguments ******************************* -->
-  <arg name="concert_name" default="concert"/>  <!-- This becomes a gateway hub whitelist variable -->
+  <arg name="concert_whitelist" default=""/>  <!-- This becomes a gateway hub whitelist variable (semi-colon separated list of python regex patterns) -->
   <arg name="robot_name" default="cybernetic_pirate"/>
   <arg name="robot_type" default="turtlebot"/>
   <arg name="rapp_lists" default="$(find rocon_apps)/apps/rocon.rapps"/> <!-- semi colon separated list --> 
@@ -20,7 +20,7 @@
     <arg name="robot_type" value="$(arg robot_type)" />
     <arg name="rapp_lists" value="$(arg rapp_lists)" />
     <arg name="gateway_watch_loop_period" value="$(arg gateway_watch_loop_period)" />
-    <arg name="hub_whitelist" value="$(arg concert_name)" />
+    <arg name="hub_whitelist" value="$(arg concert_whitelist)" />
     <arg name="disable_uuids" value="$(arg disable_uuids)"/>
     <arg name="auto_start_rapp" value="$(arg auto_start_rapp)" />
     <arg name="local_remote_controllers_only" value="$(arg local_remote_controllers_only)" />


### PR DESCRIPTION
Not a technical change, but change the terminology to give a more correct reflection and set a saner default (empty).
