### PR TITLE
Bugfix misfiring app list in paired mode

### DIFF
--- a/rocon_app_manager/concert/paired.concert
+++ b/rocon_app_manager/concert/paired.concert
@@ -1,4 +1,6 @@
 <concert>
   <launch package="rocon_app_manager" name="paired_public.launch" port="11311"/>
-  <launch package="rocon_app_manager" name="paired_private.launch" port="11312"/>
+  <launch package="rocon_app_manager" name="paired_private.launch" port="11312">
+    <arg name="disable_uuids" value="true"/>
+  </launch>
 </concert>

--- a/rocon_app_manager/launch/includes/_app_manager_gateway.xml
+++ b/rocon_app_manager/launch/includes/_app_manager_gateway.xml
@@ -14,7 +14,7 @@
   <arg name="gateway_watch_loop_period" default="5"/>
   <arg name="hub_whitelist" default=""/> <!-- semi-colon separated hub names/regex patterns -->
   <arg name="disable_uuids" default="false"/> <!-- manage unique naming of multiple gateways yourself -->
-  <arg name="gateway_network_interface" default="$(optenv GATEWAY_NETWORK_INTERFACE)"/>/>  <!-- If you have multiple network interfaces and want to lock it on one (e.g. 'eth0') -->
+  <arg name="gateway_network_interface" default="$(optenv GATEWAY_NETWORK_INTERFACE)"/>  <!-- If you have multiple network interfaces and want to lock it on one (e.g. 'eth0') -->
 
   <node pkg="rocon_gateway" type="gateway.py" name="gateway">
     <rosparam command="load" file="$(find rocon_gateway)/param/default.yaml" />
@@ -22,8 +22,8 @@
     <rosparam command="load" file="$(find rocon_app_manager)/param/app_manager_advertisements.yaml" />
     <rosparam command="load" file="$(find rocon_app_manager)/param/app_manager_flips.yaml" />
     <rosparam param="hub_uri">http://localhost:6380</rosparam> <!-- The paired hub, if available -->
-    <param name="name" value="$(arg gateway_name)"/> <!-- <rosparam param="name" subst_value="true">$(arg robot_name)</rosparam> -->
     <rosparam param="firewall">true</rosparam> <!-- Nothing comes in! -->
+    <param name="name" value="$(arg gateway_name)"/> <!-- <rosparam param="name" subst_value="true">$(arg robot_name)</rosparam> -->
     <param name="watch_loop_period" value="$(arg gateway_watch_loop_period)"/>
     <param name="hub_whitelist" value="$(arg hub_whitelist)"/>
     <param name="disable_uuids" value="$(arg disable_uuids)"/>

--- a/rocon_app_manager/launch/paired_public.launch
+++ b/rocon_app_manager/launch/paired_public.launch
@@ -6,6 +6,7 @@
 <launch>
   <!-- ************************* Public Arguments ****************************** -->
   <arg name="auto_invite" default="false"/>  <!-- Take control of the private app manager automatically (should not be true if doing multi-robot) -->
+  <arg name="gateway_network_interface" default="$(optenv GATEWAY_NETWORK_INTERFACE)"/>  <!-- If you have multiple network interfaces and want to lock it on one (e.g. 'eth0') -->
 
   <!-- ********************************* Hub *********************************** -->
   <include file="$(find rocon_hub)/launch/hub.launch">
@@ -41,6 +42,7 @@
     <rosparam param="watch_loop_period">5</rosparam>
     <rosparam param="firewall">false</rosparam>
     <rosparam param="disable_zeroconf">true</rosparam>
+    <rosparam param="network_interface" subst_value="true">$(arg gateway_network_interface)</rosparam>
   </node>
 
   <!--

--- a/rocon_app_manager/src/rocon_app_manager/rapp.py
+++ b/rocon_app_manager/src/rocon_app_manager/rapp.py
@@ -64,8 +64,10 @@ class Rapp(object):
         implementation (Jihoon)
     '''
     # I should add a __slots__ definition here to make it easy to read
-    path = None
-    data = {}
+
+    # args that can be parsed for inside a rapp launcher, these args
+    # get passed down in the temporary launcher that gets constructed when
+    # pushing down a namespace.
     standard_args = ['gateway_name', 'application_namespace', 'platform_os'
                      'platform_version', 'platform_system', 'platform_type'
                      'platform_name']
@@ -79,12 +81,17 @@ class Rapp(object):
           @param resource_share : how many can share this app.
           @type uint16
         '''
+        # dic containing all relevant configuration variables for this rapp.
+        # Refer to load_from_rapp_file and don't forget the share variable.
+        self.data = {}
         self.filename = ""
         self._connections = {}
         for connection_type in ['publishers', 'subscribers', 'services', 'action_clients', 'action_servers']:
             self._connections[connection_type] = []
 
         self._load_from_resource_name(resource_name, rospack=rospack)
+        # Black magic here - make sure self.data is set in _load_from_resource_name first.
+        # What if it failed? Should get the above to return self.data instead.
         self.data['share'] = resource_share
 
     def __repr__(self):


### PR DESCRIPTION
Fixed #120 previously, but made the mistake of only testing standalone mode. It was still not firing properly in paired mode.

This bugfix just makes sure it re-calls the app list publisher when it re-initialises the publisher after discovering the gateway.

Also changed the option in paired.concert to disable uuids. They are a pain in the ass for testing and I don't think we use this rocon launcher outside of testing. Or do we?
