### PR TITLE
Added rocon_app install for installing rapps dependencies

### DIFF
--- a/rocon_app_utilities/src/rocon_app_utilities/__init__.py
+++ b/rocon_app_utilities/src/rocon_app_utilities/__init__.py
@@ -5,5 +5,6 @@
 #
 #################################################################################
 
+from .dependencies import DependencyChecker
 from .indexer import RappIndexer
 from .rapp import Rapp

--- a/rocon_app_utilities/src/rocon_app_utilities/dependencies.py
+++ b/rocon_app_utilities/src/rocon_app_utilities/dependencies.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python
+#
+# License: BSD
+#   https://raw.github.com/robotics-in-concert/rocon_app_platform/license/LICENSE
+#
+#################################################################################
+
+import platform
+
+from rosdep2 import RosdepLookup, create_default_installer_context, ResolutionError
+from rosdep2.installers import RosdepInstaller
+from rosdep2.sources_list import SourcesListLoader
+from rosdep2.rospkg_loader import DEFAULT_VIEW_KEY
+
+from .exceptions import *
+
+
+class DependencyChecker(object):
+
+    def __init__(self, indexer, ros_distro=None, os_name=None, os_id=None):
+        self.indexer = indexer
+
+        import os
+        if not os_name:
+            os_platform = platform.system().lower()
+            if os_platform == 'linux':
+                # Retrieve distribution name
+                os_name, os_version, os_id = platform.linux_distribution()
+                os_name = os_name.lower()
+            else:
+               # We only support Linux for now
+               raise UnsupportedPlatformException(os_platform)
+
+        self.os_name = os_name
+        self.os_id = os_id
+
+        # FIXME: there should be a way to set this without using an environment variable
+        if ros_distro:
+            os.environ['ROS_DISTRO'] = ros_distro
+
+
+        self.sources_loader = SourcesListLoader.create_default(verbose=False)
+        self.lookup = RosdepLookup.create_from_rospkg(sources_loader=self.sources_loader)
+        self.installer_context = create_default_installer_context(verbose=False)
+        self.installer_keys = self.installer_context.get_os_installer_keys(self.os_name)
+ 
+        self.default_key = self.installer_context.get_default_os_installer_key(self.os_name)
+        self.installer = self.installer_context.get_installer(self.default_key)
+ 
+        self.view = self.lookup.get_rosdep_view(DEFAULT_VIEW_KEY, verbose=False)
+
+    def check_missing_rapp_dependencies(self, rapp_names):
+        '''
+        Check that a given list of Rapps have all their dependencies installed.
+
+        @param rapp_names: A C{list} of ROCON URIs
+
+        @return: A C{list} of ROCON URIs whose dependencies are already installed in the system.
+        '''
+        fulfilled_dependencies = []
+        for rapp_name in rapp_names:
+            rapp = self.indexer.get_rapp(rapp_name)
+            rapp_dependencies = [run_depends.name for run_depends in rapp.package.run_depends]
+
+            rosdep_installer = RosdepInstaller(self.installer_context, self.lookup)
+            uninstalled, errors = rosdep_installer.get_uninstalled(rapp_dependencies)
+            if not uninstalled:
+                fulfilled_dependencies.append(rapp_name)
+
+        return fulfilled_dependencies
+
+    def install_rapp_dependencies(self, rapp_names):
+        '''
+        Install the depenedencies for a given list of Rapps.
+
+        @param rapp_name: A C{list} of ROCON URIs
+        '''
+        pkg_deps = []
+        for rapp_name in rapp_names:
+            rapp = self.indexer.get_rapp(rapp_name)
+            for run_depend in rapp.package.run_depends:
+                try:
+                    d = self.view.lookup(run_depend.name)
+                    inst_key, rule = d.get_rule_for_platform(
+                        self.os_name, self.os_id, self.installer_keys, self.default_key
+                    )
+                    pkg_deps.extend(self.installer.resolve(rule))
+                except KeyError:
+                    pass
+ 
+
+        rosdep_installer = RosdepInstaller(self.installer_context, self.lookup)
+        rosdep_installer.install_resolved(self.default_key, pkg_deps)

--- a/rocon_app_utilities/src/rocon_app_utilities/exceptions.py
+++ b/rocon_app_utilities/src/rocon_app_utilities/exceptions.py
@@ -85,3 +85,10 @@ class RappMalformedException(RappException):
     '''
       If rapp contains missing key...
     '''
+
+
+class UnsupportedPlatformException(Exception):
+    '''
+      If running on a platform not supported by rosdep.
+    '''
+    pass

--- a/rocon_app_utilities/src/rocon_app_utilities/exceptions.py
+++ b/rocon_app_utilities/src/rocon_app_utilities/exceptions.py
@@ -92,3 +92,10 @@ class UnsupportedPlatformException(Exception):
       If running on a platform not supported by rosdep.
     '''
     pass
+
+
+class NonInstallableRappException(Exception):
+    '''
+      If Rapp cannot be installed.
+    '''
+    pass

--- a/rocon_app_utilities/src/rocon_app_utilities/indexer.py
+++ b/rocon_app_utilities/src/rocon_app_utilities/indexer.py
@@ -45,10 +45,11 @@ class RappIndexer(object):
         raw_data = {}
         invalid_data = {}
 
-        for resource_name, path in self.raw_data_path.items():
+        for resource_name, (rapp_path, package) in self.raw_data_path.items():
             try:
                 r = Rapp(resource_name, self.rospack)
-                r.load_rapp_yaml_from_file(path)
+                r.load_rapp_yaml_from_file(rapp_path)
+                r.package = package
                 raw_data[resource_name] = r
             except InvalidRappFieldException as irfe:
                 invalid_data[resource_name] = str(irfe)

--- a/rocon_app_utilities/src/rocon_app_utilities/rapp.py
+++ b/rocon_app_utilities/src/rocon_app_utilities/rapp.py
@@ -22,7 +22,7 @@ class Rapp(object):
     '''
         Rocon(or Robot) App definition.
     '''
-    __slots__ = ['resource_name', 'raw_data', 'data', 'type', 'is_implementation', 'is_ancestor', 'ancestor_name', 'parent_name', 'rospack']
+    __slots__ = ['resource_name', 'raw_data', 'data', 'type', 'is_implementation', 'is_ancestor', 'ancestor_name', 'parent_name', 'rospack', 'package']
 
     def __init__(self, name, rospack=rospkg.RosPack(), filename=None):
         self.resource_name = name
@@ -36,6 +36,8 @@ class Rapp(object):
 
         if filename:
             self.load_rapp_yaml_from_file(filename)
+
+        self.package = None
 
     def __str__(self):
         return str(self.resource_name + ' - ' + self.type)

--- a/rocon_app_utilities/src/rocon_app_utilities/rapp_cmd.py
+++ b/rocon_app_utilities/src/rocon_app_utilities/rapp_cmd.py
@@ -135,18 +135,23 @@ def _rapp_cmd_install(argv):
     rapp_names = set(parsed_args.rapp_names)
 
     indexer = RappIndexer()
-    compatible_rapps, incompatible_rapps, invalid_rapps = indexer.get_compatible_rapps(ancestor_share_check=False)
 
-    compatible_rapp_names = set(compatible_rapps.keys())
-    installable_rapp_names = compatible_rapp_names.intersection(rapp_names)
-    noninstallable_rapp_names = rapp_names.difference(installable_rapp_names)
+    dependencyChecker = DependencyChecker(indexer)
 
-    if noninstallable_rapp_names:
-        print('Error - The following rapps cannot be installed: %s' % (' '.join(noninstallable_rapp_names)))
+    installable_rapps, noninstallable_rapps = dependencyChecker.check_missing_rapp_dependencies(rapp_names)
+
+    missing_dependencies = []
+    for rapp_name, dependencies in noninstallable_rapps.iteritems():
+        missing_dependencies.extend(dependencies)
+    missing_dependencies = set(missing_dependencies)
+
+    if noninstallable_rapps:
+        print('Error - The following rapps cannot be installed: %s. Missing dependencies: %s' % (' '.join(noninstallable_rapps.keys()),
+                                                                                                 ' '.join(missing_dependencies)
+                                                                                                ))
     else:
         # resolve deps and install them
         print("Installing dependencies for: %s" % (' '.join(sorted(rapp_names))))
-        dependencyChecker = DependencyChecker(indexer)
         dependencyChecker.install_rapp_dependencies(rapp_names)
 
 


### PR DESCRIPTION
This branch adds an install command to rocon_app that installs Rapps' dependencies and a module that checks that the given Rapp has all their dependencies installed.

Depends on https://github.com/robotics-in-concert/rocon_tools/pull/23

Resolves #190 and #191
