### PR TITLE
Disabling required on chirp

### DIFF
--- a/rocon_apps/apps/chirp/chirp.launch
+++ b/rocon_apps/apps/chirp/chirp.launch
@@ -1,3 +1,3 @@
 <launch>
-  <node name="chirp" pkg="rocon_apps" type="chirp.bash" args="$(find rocon_apps)/sounds/cow.wav" required="true"/>
+  <node name="chirp" pkg="rocon_apps" type="chirp.bash" args="$(find rocon_apps)/sounds/cow.wav"/>
 </launch>


### PR DESCRIPTION
This node is meant to die, having required here does nothing (roslaunch already down) and creates alot of bleeding!
