### PR TITLE
simulated robot support in app manager

### DIFF
--- a/rocon_app_manager/launch/concert_client.launch
+++ b/rocon_app_manager/launch/concert_client.launch
@@ -33,6 +33,9 @@
   <arg name="interactions"          default="false"/>
   <arg name="interactions_list"     default="[]"/>
 
+  <!-- *************************** Is simulataion ******************************* -->
+  <arg name="sim"                   default="false"/>
+
   <!-- ************************* Rarely Used Variables ************************** -->
   <arg name="firewall" default="false"/> <!-- typically false (don't let anything in), only for simulation clients -->
   
@@ -59,6 +62,7 @@
     <arg name="robot_icon"                     value="$(arg robot_icon)" />
     <arg name="robot_type"                     value="$(arg robot_type)" />
     <arg name="screen"                         value="$(arg screen)" />
+    <arg name="sim"                            value="$(arg sim)" />
   </include>
 
 </launch>

--- a/rocon_app_manager/launch/concert_client.launch
+++ b/rocon_app_manager/launch/concert_client.launch
@@ -34,7 +34,7 @@
   <arg name="interactions_list"     default="[]"/>
 
   <!-- *************************** Is simulataion ******************************* -->
-  <arg name="sim"                   default="false"/>
+  <arg name="sim"                   default="false"/> <!-- simulated robot -->
 
   <!-- ************************* Rarely Used Variables ************************** -->
   <arg name="firewall" default="false"/> <!-- typically false (don't let anything in), only for simulation clients -->

--- a/rocon_app_manager/launch/concert_client.launch
+++ b/rocon_app_manager/launch/concert_client.launch
@@ -34,7 +34,7 @@
   <arg name="interactions_list"     default="[]"/>
 
   <!-- *************************** Is simulataion ******************************* -->
-  <arg name="sim"                   default="false"/> <!-- simulated robot -->
+  <arg name="simulation"                   default="false"/> <!-- simulated robot -->
 
   <!-- ************************* Rarely Used Variables ************************** -->
   <arg name="firewall" default="false"/> <!-- typically false (don't let anything in), only for simulation clients -->
@@ -62,7 +62,7 @@
     <arg name="robot_icon"                     value="$(arg robot_icon)" />
     <arg name="robot_type"                     value="$(arg robot_type)" />
     <arg name="screen"                         value="$(arg screen)" />
-    <arg name="sim"                            value="$(arg sim)" />
+    <arg name="simulation"                            value="$(arg simulation)" />
   </include>
 
 </launch>

--- a/rocon_app_manager/launch/includes/_app_manager.xml
+++ b/rocon_app_manager/launch/includes/_app_manager.xml
@@ -12,7 +12,7 @@
   <arg name="rapp_package_blacklist" default="[]"/>
   <arg name="auto_start_rapp" default=""/> <!-- autostart a rapp, e.g. rocon_apps/chirp -->
   <arg name="screen" default="false"/>  <!-- verbose output from running apps -->
-  <arg name="sim" default="false"/> <!-- is simulated robot in gazebo -->
+  <arg name="simulation" default="false"/> <!-- is simulated robot in gazebo -->
   <arg name="capability_server_name" default="capability_server"/>  <!-- name of the capability server -->
   <!-- See 'http://wiki.ros.org/rocon_app_manager/Tutorials/indigo/Automatic Rapp Installation'
        on how to enable automatic rapp installation -->
@@ -29,7 +29,7 @@
     <param name="auto_start_rapp" value="$(arg auto_start_rapp)"/>
     <param name="local_remote_controllers_only" value="$(arg local_remote_controllers_only)"/>
     <param name="screen" value="$(arg screen)"/>
-    <param name="sim" value="$(arg sim)"/>
+    <param name="simulation" value="$(arg simulation)"/>
     <param name="capability_server_name" value="$(arg capability_server_name)"/>
     <param name="auto_rapp_installation" value="$(arg auto_rapp_installation)" />
     <remap from="app_manager/gateway_info" to="gateway/gateway_info"/>

--- a/rocon_app_manager/launch/includes/_app_manager.xml
+++ b/rocon_app_manager/launch/includes/_app_manager.xml
@@ -12,6 +12,7 @@
   <arg name="rapp_package_blacklist" default="[]"/>
   <arg name="auto_start_rapp" default=""/> <!-- autostart a rapp, e.g. rocon_apps/chirp -->
   <arg name="screen" default="false"/>  <!-- verbose output from running apps -->
+  <arg name="sim" default="false"/> <!-- is simulated robot in gazebo -->
   <arg name="capability_server_name" default="capability_server"/>  <!-- name of the capability server -->
   <!-- See 'http://wiki.ros.org/rocon_app_manager/Tutorials/indigo/Automatic Rapp Installation'
        on how to enable automatic rapp installation -->
@@ -28,6 +29,7 @@
     <param name="auto_start_rapp" value="$(arg auto_start_rapp)"/>
     <param name="local_remote_controllers_only" value="$(arg local_remote_controllers_only)"/>
     <param name="screen" value="$(arg screen)"/>
+    <param name="sim" value="$(arg sim)"/>
     <param name="capability_server_name" value="$(arg capability_server_name)"/>
     <param name="auto_rapp_installation" value="$(arg auto_rapp_installation)" />
     <remap from="app_manager/gateway_info" to="gateway/gateway_info"/>

--- a/rocon_app_manager/launch/multimaster.launch
+++ b/rocon_app_manager/launch/multimaster.launch
@@ -46,7 +46,7 @@
   <arg name="robot_type"                    default="pc"/>
   <arg name="robot_icon"                    default="rocon_icons/cybernetic_pirate.png"/> 
   <arg name="screen"                        default="false"/>             <!-- verbose output from running apps -->
-  <arg name="sim"                           default="false"/>
+  <arg name="sim"                           default="false"/>             <!-- simulated robot -->
 
   <include file="$(find rocon_app_manager)/launch/includes/_app_manager.xml">
     <arg name="robot_name" value="$(arg robot_name)" />

--- a/rocon_app_manager/launch/multimaster.launch
+++ b/rocon_app_manager/launch/multimaster.launch
@@ -46,7 +46,7 @@
   <arg name="robot_type"                    default="pc"/>
   <arg name="robot_icon"                    default="rocon_icons/cybernetic_pirate.png"/> 
   <arg name="screen"                        default="false"/>             <!-- verbose output from running apps -->
-  <arg name="sim"                           default="false"/>             <!-- simulated robot -->
+  <arg name="simulation"                    default="false"/>             <!-- simulated robot -->
 
   <include file="$(find rocon_app_manager)/launch/includes/_app_manager.xml">
     <arg name="robot_name" value="$(arg robot_name)" />
@@ -57,7 +57,7 @@
     <arg name="auto_start_rapp" value="$(arg auto_start_rapp)" />
     <arg name="local_remote_controllers_only" value="$(arg local_remote_controllers_only)" />
     <arg name="screen" value="$(arg screen)" />
-    <arg name="sim" value="$(arg sim)"/>
+    <arg name="simulation" value="$(arg simulation)"/>
     <arg name="capability_server_name" value="$(arg capabilities_server_name)" if="$(arg capabilities)"/>
     <arg name="auto_rapp_installation" value="$(arg auto_rapp_installation)" />
   </include>

--- a/rocon_app_manager/launch/multimaster.launch
+++ b/rocon_app_manager/launch/multimaster.launch
@@ -46,6 +46,7 @@
   <arg name="robot_type"                    default="pc"/>
   <arg name="robot_icon"                    default="rocon_icons/cybernetic_pirate.png"/> 
   <arg name="screen"                        default="false"/>             <!-- verbose output from running apps -->
+  <arg name="sim"                           default="false"/>
 
   <include file="$(find rocon_app_manager)/launch/includes/_app_manager.xml">
     <arg name="robot_name" value="$(arg robot_name)" />
@@ -56,6 +57,7 @@
     <arg name="auto_start_rapp" value="$(arg auto_start_rapp)" />
     <arg name="local_remote_controllers_only" value="$(arg local_remote_controllers_only)" />
     <arg name="screen" value="$(arg screen)" />
+    <arg name="sim" value="$(arg sim)"/>
     <arg name="capability_server_name" value="$(arg capabilities_server_name)" if="$(arg capabilities)"/>
     <arg name="auto_rapp_installation" value="$(arg auto_rapp_installation)" />
   </include>

--- a/rocon_app_manager/launch/standalone.launch
+++ b/rocon_app_manager/launch/standalone.launch
@@ -30,7 +30,8 @@
   <arg name="robot_name"             default="Cybernetic Pirate"/>
   <arg name="robot_type"             default="pc"/>
   <arg name="robot_icon"             default="rocon_icons/cybernetic_pirate.png"/>
-  <arg name="screen" default="true"/>  <!-- verbose output from running apps -->
+  <arg name="screen"                 default="true"/>  <!-- verbose output from running apps -->
+  <arg name="sim"                    default="false"/> <!-- simulated robot -->
 
   <include file="$(find rocon_app_manager)/launch/includes/_app_manager.xml">
     <arg name="robot_name" value="$(arg robot_name)" />
@@ -40,6 +41,7 @@
     <arg name="rapp_package_blacklist" value="$(arg rapp_package_blacklist)" />
     <arg name="auto_start_rapp" value="$(arg auto_start_rapp)" />
     <arg name="screen" value="$(arg screen)" />
+    <arg name="sim" value="$(arg sim)"/>
     <arg name="auto_rapp_installation" value="$(arg auto_rapp_installation)" />
     <arg name="capability_server_name" default="$(arg capabilities_server_name)"/>
   </include>

--- a/rocon_app_manager/launch/standalone.launch
+++ b/rocon_app_manager/launch/standalone.launch
@@ -31,7 +31,7 @@
   <arg name="robot_type"             default="pc"/>
   <arg name="robot_icon"             default="rocon_icons/cybernetic_pirate.png"/>
   <arg name="screen"                 default="true"/>  <!-- verbose output from running apps -->
-  <arg name="sim"                    default="false"/> <!-- simulated robot -->
+  <arg name="simulation"             default="false"/> <!-- simulated robot -->
 
   <include file="$(find rocon_app_manager)/launch/includes/_app_manager.xml">
     <arg name="robot_name" value="$(arg robot_name)" />
@@ -41,7 +41,7 @@
     <arg name="rapp_package_blacklist" value="$(arg rapp_package_blacklist)" />
     <arg name="auto_start_rapp" value="$(arg auto_start_rapp)" />
     <arg name="screen" value="$(arg screen)" />
-    <arg name="sim" value="$(arg sim)"/>
+    <arg name="simulation" value="$(arg simulation)"/>
     <arg name="auto_rapp_installation" value="$(arg auto_rapp_installation)" />
     <arg name="capability_server_name" default="$(arg capabilities_server_name)"/>
   </include>

--- a/rocon_app_manager/src/rocon_app_manager/rapp.py
+++ b/rocon_app_manager/src/rocon_app_manager/rapp.py
@@ -107,7 +107,7 @@ class Rapp(object):
 
         return success, str()
 
-    def start(self, application_namespace, gateway_name, rocon_uri_string, remappings=[], parameters=[], force_screen=False, sim=False,
+    def start(self, application_namespace, gateway_name, rocon_uri_string, remappings=[], parameters=[], force_screen=False, simulation=False,
               caps_list=None):
         '''
           Some important jobs here.
@@ -131,8 +131,8 @@ class Rapp(object):
           :type parameters: list of rocon_std_msgs.msg.KeyValue
           :param force_screen: whether to roslaunch the app with --screen or not
           :type force_screen: boolean
-          :param sim: whether the rapp manager is for simulated robot or not
-          :type sim: boolean
+          :param simulation: whether the rapp manager is for simulated robot or not
+          :type simulation: boolean
           :param caps_list: this holds the list of available capabilities, if app needs capabilities
           :type caps_list: CapsList
         '''
@@ -144,7 +144,7 @@ class Rapp(object):
             public_parameters = utils.apply_requested_public_parameters(data['public_parameters'], parameters)
 
             temp = tempfile.NamedTemporaryFile(mode='w+t', delete=False)
-            self._launch = utils.prepare_launcher(data, public_parameters, application_namespace, gateway_name, rocon_uri_string, capability_nodelet_manager_name, force_screen, sim, temp)
+            self._launch = utils.prepare_launcher(data, public_parameters, application_namespace, gateway_name, rocon_uri_string, capability_nodelet_manager_name, force_screen, simulation, temp)
 
             # Better logic for the future, 1) get remap rules from capabilities. 2) get remap rules from requets. 3) apply them all. It would be clearer to understand the logic and easily upgradable
             if 'required_capabilities' in data:  # apply capability-specific remappings needed

--- a/rocon_app_manager/src/rocon_app_manager/rapp.py
+++ b/rocon_app_manager/src/rocon_app_manager/rapp.py
@@ -107,7 +107,7 @@ class Rapp(object):
 
         return success, str()
 
-    def start(self, application_namespace, gateway_name, rocon_uri_string, remappings=[], parameters=[], force_screen=False,
+    def start(self, application_namespace, gateway_name, rocon_uri_string, remappings=[], parameters=[], force_screen=False, sim=False,
               caps_list=None):
         '''
           Some important jobs here.
@@ -131,6 +131,8 @@ class Rapp(object):
           :type parameters: list of rocon_std_msgs.msg.KeyValue
           :param force_screen: whether to roslaunch the app with --screen or not
           :type force_screen: boolean
+          :param sim: whether the rapp manager is for simulated robot or not
+          :type sim: boolean
           :param caps_list: this holds the list of available capabilities, if app needs capabilities
           :type caps_list: CapsList
         '''
@@ -142,7 +144,7 @@ class Rapp(object):
             public_parameters = utils.apply_requested_public_parameters(data['public_parameters'], parameters)
 
             temp = tempfile.NamedTemporaryFile(mode='w+t', delete=False)
-            self._launch = utils.prepare_launcher(data, public_parameters, application_namespace, gateway_name, rocon_uri_string, capability_nodelet_manager_name, force_screen, temp)
+            self._launch = utils.prepare_launcher(data, public_parameters, application_namespace, gateway_name, rocon_uri_string, capability_nodelet_manager_name, force_screen, sim, temp)
 
             # Better logic for the future, 1) get remap rules from capabilities. 2) get remap rules from requets. 3) apply them all. It would be clearer to understand the logic and easily upgradable
             if 'required_capabilities' in data:  # apply capability-specific remappings needed

--- a/rocon_app_manager/src/rocon_app_manager/rapp_manager.py
+++ b/rocon_app_manager/src/rocon_app_manager/rapp_manager.py
@@ -559,6 +559,7 @@ class RappManager(object):
                        req.remappings,
                        req.parameters,
                        self._param['app_output_to_screen'],
+                       self._param['sim'],
                        self.caps_list)
 
         rospy.loginfo("Rapp Manager : %s" % self._remote_name)

--- a/rocon_app_manager/src/rocon_app_manager/rapp_manager.py
+++ b/rocon_app_manager/src/rocon_app_manager/rapp_manager.py
@@ -559,7 +559,7 @@ class RappManager(object):
                        req.remappings,
                        req.parameters,
                        self._param['app_output_to_screen'],
-                       self._param['sim'],
+                       self._param['simulation'],
                        self.caps_list)
 
         rospy.loginfo("Rapp Manager : %s" % self._remote_name)

--- a/rocon_app_manager/src/rocon_app_manager/ros_parameters.py
+++ b/rocon_app_manager/src/rocon_app_manager/ros_parameters.py
@@ -41,4 +41,7 @@ def setup_ros_parameters():
     # Preferred rapp configuration
     param['preferred'] = rospy.get_param('~preferred',[])
 
+    # Simulation
+    param['sim'] = rospy.get_param('~sim', False)
+
     return param

--- a/rocon_app_manager/src/rocon_app_manager/ros_parameters.py
+++ b/rocon_app_manager/src/rocon_app_manager/ros_parameters.py
@@ -42,6 +42,6 @@ def setup_ros_parameters():
     param['preferred'] = rospy.get_param('~preferred',[])
 
     # Simulation
-    param['sim'] = rospy.get_param('~sim', False)
+    param['simulation'] = rospy.get_param('~simulation', False)
 
     return param

--- a/rocon_app_manager/src/rocon_app_manager/utils.py
+++ b/rocon_app_manager/src/rocon_app_manager/utils.py
@@ -33,7 +33,7 @@ def dict_to_KeyValue(d):
 
 
 def _prepare_launch_text(launch_file, launch_args, public_parameters, application_namespace,
-                         gateway_name, rocon_uri_string, sim, capability_server_nodelet_manager_name=None):
+                         gateway_name, rocon_uri_string, simulation, capability_server_nodelet_manager_name=None):
     '''
       Prepare the launch file text. This essentially wraps the rapp launcher
       with the following roslaunch elements:
@@ -60,8 +60,8 @@ def _prepare_launch_text(launch_file, launch_args, public_parameters, applicatio
       :type gateway_name: str
       :param rocon_uri_string: used to pass down information about the platform that is running this app to the app itself.
       :type rocon_uri_string: str - a rocon uri string
-      :param sim: true if rapp manager is for simulated robot
-      :type sim: boolen
+      :param simulation: true if rapp manager is for simulated robot
+      :type simulation: boolen
 
       The rocon_uri_string variable is a fixed identifier for this app manager's platform - i.e. no special
       characters or wildcards should be contained therein.
@@ -73,7 +73,7 @@ def _prepare_launch_text(launch_file, launch_args, public_parameters, applicatio
     launch_arg_mapping['gateway_name'] = gateway_name
     launch_arg_mapping['rocon_uri'] = rocon_uri_string
     launch_arg_mapping['capability_server_nodelet_manager_name'] = capability_server_nodelet_manager_name
-    launch_arg_mapping['sim'] = sim
+    launch_arg_mapping['simulation'] = simulation
 
     if(application_namespace == ""):
         launch_text = '<launch>\n  <include file="%s">\n' % (launch_file)
@@ -113,7 +113,7 @@ def resolve_chain_remappings(nodes):
         n.remap_args = new_remap_args_dict.items()
 
 
-def prepare_launcher(data, public_parameters, application_namespace, gateway_name, rocon_uri_string, capability_nodelet_manager_name, force_screen, sim, temp):
+def prepare_launcher(data, public_parameters, application_namespace, gateway_name, rocon_uri_string, capability_nodelet_manager_name, force_screen, simulation, temp):
     '''
       prepare roslaunch to start rapp.
     '''
@@ -125,7 +125,7 @@ def prepare_launcher(data, public_parameters, application_namespace, gateway_nam
                                        application_namespace,
                                        gateway_name,
                                        rocon_uri_string,
-                                       sim,
+                                       simulation,
                                        capability_nodelet_manager_name
                                        )
     temp.write(launch_text)

--- a/rocon_app_manager/src/rocon_app_manager/utils.py
+++ b/rocon_app_manager/src/rocon_app_manager/utils.py
@@ -33,7 +33,7 @@ def dict_to_KeyValue(d):
 
 
 def _prepare_launch_text(launch_file, launch_args, public_parameters, application_namespace,
-                         gateway_name, rocon_uri_string, capability_server_nodelet_manager_name=None):
+                         gateway_name, rocon_uri_string, sim, capability_server_nodelet_manager_name=None):
     '''
       Prepare the launch file text. This essentially wraps the rapp launcher
       with the following roslaunch elements:
@@ -60,6 +60,8 @@ def _prepare_launch_text(launch_file, launch_args, public_parameters, applicatio
       :type gateway_name: str
       :param rocon_uri_string: used to pass down information about the platform that is running this app to the app itself.
       :type rocon_uri_string: str - a rocon uri string
+      :param sim: true if rapp manager is for simulated robot
+      :type sim: boolen
 
       The rocon_uri_string variable is a fixed identifier for this app manager's platform - i.e. no special
       characters or wildcards should be contained therein.
@@ -71,6 +73,7 @@ def _prepare_launch_text(launch_file, launch_args, public_parameters, applicatio
     launch_arg_mapping['gateway_name'] = gateway_name
     launch_arg_mapping['rocon_uri'] = rocon_uri_string
     launch_arg_mapping['capability_server_nodelet_manager_name'] = capability_server_nodelet_manager_name
+    launch_arg_mapping['sim'] = sim
 
     if(application_namespace == ""):
         launch_text = '<launch>\n  <include file="%s">\n' % (launch_file)
@@ -110,7 +113,7 @@ def resolve_chain_remappings(nodes):
         n.remap_args = new_remap_args_dict.items()
 
 
-def prepare_launcher(data, public_parameters, application_namespace, gateway_name, rocon_uri_string, capability_nodelet_manager_name, force_screen, temp):
+def prepare_launcher(data, public_parameters, application_namespace, gateway_name, rocon_uri_string, capability_nodelet_manager_name, force_screen, sim, temp):
     '''
       prepare roslaunch to start rapp.
     '''
@@ -122,7 +125,9 @@ def prepare_launcher(data, public_parameters, application_namespace, gateway_nam
                                        application_namespace,
                                        gateway_name,
                                        rocon_uri_string,
-                                       capability_nodelet_manager_name)
+                                       sim,
+                                       capability_nodelet_manager_name
+                                       )
     temp.write(launch_text)
     temp.close()  # unlink it later
 

--- a/rocon_app_utilities/src/rocon_app_utilities/rapp_loader.py
+++ b/rocon_app_utilities/src/rocon_app_utilities/rapp_loader.py
@@ -198,7 +198,7 @@ def _get_standard_args(roslaunch_file):
 
       :raises RappMalformedException: if launch file format is invalid
     '''
-    standard_args = ['gateway_name', 'application_namespace', 'rocon_uri', 'capability_server_nodelet_manager_name']
+    standard_args = ['gateway_name', 'application_namespace', 'rocon_uri', 'capability_server_nodelet_manager_name', 'sim']
 
     try:
         available_args = _get_available_args(roslaunch_file)

--- a/rocon_app_utilities/src/rocon_app_utilities/rapp_loader.py
+++ b/rocon_app_utilities/src/rocon_app_utilities/rapp_loader.py
@@ -198,7 +198,7 @@ def _get_standard_args(roslaunch_file):
 
       :raises RappMalformedException: if launch file format is invalid
     '''
-    standard_args = ['gateway_name', 'application_namespace', 'rocon_uri', 'capability_server_nodelet_manager_name', 'sim']
+    standard_args = ['gateway_name', 'application_namespace', 'rocon_uri', 'capability_server_nodelet_manager_name', 'simulation']
 
     try:
         available_args = _get_available_args(roslaunch_file)


### PR DESCRIPTION
`sim` indicates that the app manager is for simulated robot. It passes `sim` argument to rapp launcher.
