### PR TITLE
forcing service creation to be done only once, via parameter.

### DIFF
--- a/rocon_app_manager/launch/includes/_app_manager.xml
+++ b/rocon_app_manager/launch/includes/_app_manager.xml
@@ -1,12 +1,13 @@
 <!--
-  Default launch configuration for the app manager in paired or concert mode. 
+  Default launch configuration for the app manager in paired or concert mode.
  -->
 <launch>
   <!-- ************************* Public Arguments ****************************** -->
   <!-- These go into the advertised platform_info -->
-  <arg name="robot_name" default="Cybernetic Pirate"/> 
-  <arg name="robot_type" default="turtlebot"/> 
+  <arg name="robot_name" default="Cybernetic Pirate"/>
+  <arg name="robot_type" default="turtlebot"/>
   <arg name="robot_icon" default="$(find rocon_app_manager)/icons/turtlebot.png"/>
+  <arg name="use_gateway_uuids" default="true" doc="wait for gateway before setting up services under namespace with uuid" />
   <arg name="local_remote_controllers_only" default="false" doc="allow remote control for local machine tests only"/>
   <arg name="rapp_package_whitelist" default="[]" doc="comma separated list of package names"/>
   <arg name="rapp_package_blacklist" default="[]"/>
@@ -27,6 +28,7 @@
     <param name="robot_name" value="$(arg robot_name)"/>
     <param name="robot_type" value="$(arg robot_type)"/>
     <param name="robot_icon" value="$(arg robot_icon)"/>
+    <param name="use_gateway_uuids" value="$(arg use_gateway_uuids)"/>
     <param name="auto_start_rapp" value="$(arg auto_start_rapp)"/>
     <param name="local_remote_controllers_only" value="$(arg local_remote_controllers_only)"/>
     <param name="screen" value="$(arg screen)"/>

--- a/rocon_app_manager/launch/multimaster.launch
+++ b/rocon_app_manager/launch/multimaster.launch
@@ -30,7 +30,7 @@
   <arg name="capabilities_parameters"            default="$(find rocon_app_manager)/param/capabilities.yaml" doc="detailed parameter configuration for the providers" />
   <arg name="capabilities_blacklist"             default="[]" doc="blacklist specific capabilities" />
   <arg name="capabilities_nodelet_manager_name"  default="capability_server_nodelet_manager" />
-  <arg name="capabilities_package_whitelist"     default="[std_capabilities]" doc="get capabilities from these packages only" /> 
+  <arg name="capabilities_package_whitelist"     default="[std_capabilities]" doc="get capabilities from these packages only" />
   <arg name="capabilities_server_name"           default="capability_server"/>
 
   <group if="$(arg capabilities)">
@@ -47,11 +47,11 @@
   <arg name="auto_rapp_installation"        default="false" doc="http://wiki.ros.org/rocon_app_manager/Tutorials/indigo/Automatic Rapp Installation" />
   <arg name="auto_start_rapp"               default="" doc="autostart a rapp, e.g. rocon_apps/chirp" />
   <arg name="local_remote_controllers_only" default="false" doc="allow remote control for local machine tests only" />
-  <arg name="rapp_package_whitelist"        default="[rocon_apps]" doc="comma separated list of package names" /> 
+  <arg name="rapp_package_whitelist"        default="[rocon_apps]" doc="comma separated list of package names" />
   <arg name="rapp_package_blacklist"        default="[]"/>
   <arg name="rapp_preferred_configuration_file" default="$(find rocon_app_manager)/param/preferred_default.yaml"/>
   <arg name="robot_type"                    default="pc"/>
-  <arg name="robot_icon"                    default="rocon_icons/cybernetic_pirate.png"/> 
+  <arg name="robot_icon"                    default="rocon_icons/cybernetic_pirate.png"/>
   <arg name="screen"                        default="false" doc="verbose output from running apps" />
   <arg name="simulation"                    default="false" doc="if simulated robot" />
 
@@ -59,6 +59,7 @@
     <arg name="robot_name" value="$(arg robot_name)" />
     <arg name="robot_type" value="$(arg robot_type)" />
     <arg name="robot_icon" value="$(arg robot_icon)" />
+    <arg name="use_gateway_uuids" value="$(arg gateway_uuids)" />
     <arg name="rapp_package_whitelist" value="$(arg rapp_package_whitelist)" />
     <arg name="rapp_package_blacklist" value="$(arg rapp_package_blacklist)" />
     <arg name="rapp_preferred_configuration_file" value="$(arg rapp_preferred_configuration_file)" />

--- a/rocon_app_manager/launch/standalone.launch
+++ b/rocon_app_manager/launch/standalone.launch
@@ -38,6 +38,7 @@
     <arg name="robot_name" value="$(arg robot_name)" />
     <arg name="robot_type" value="$(arg robot_type)" />
     <arg name="robot_icon" value="$(arg robot_icon)" />
+    <arg name="use_gateway_uuids" value="false" />
     <arg name="rapp_package_whitelist" value="$(arg rapp_package_whitelist)" />
     <arg name="rapp_package_blacklist" value="$(arg rapp_package_blacklist)" />
     <arg name="rapp_preferred_configuration_file" value="$(arg rapp_preferred_configuration_file)" />

--- a/rocon_app_manager/src/rocon_app_manager/rapp_manager.py
+++ b/rocon_app_manager/src/rocon_app_manager/rapp_manager.py
@@ -80,7 +80,9 @@ class RappManager(object):
 
         self._init_default_service_names()
         self._init_gateway_services()
-        self._init_services()
+        #if we dont depend on gateway we can init services right now
+        if not self._param['use_gateway_uuids']:
+            self._init_services()
 
         if self._param['auto_start_rapp']:  # None and '' are both false here
             request = rapp_manager_srvs.StartRappRequest(self._param['auto_start_rapp'], [])
@@ -148,6 +150,7 @@ class RappManager(object):
             # and in the spin(), then we just use a flag to protect.
             return False
         self._initialising_services = True
+        #TOCHECK : Maybe we want to completely skip this code(keep services/topics what they are), instead of forcibly reinitializing?
         if self._services:
             for service in self._services.values():
                 service.shutdown()
@@ -156,8 +159,9 @@ class RappManager(object):
             self._services = {}
             self._publishers = {}
         self._service_names = {}
-        self._publisher_names = {}
-        base_name = self._gateway_name.lower().replace(' ', '_') if self._gateway_name else ""  # latter option is for standalone mode
+        self._publisher_names = {}        # Variable setting
+        #Standalone basename need to also be usable by concert ( until we get relays/aliases )
+        base_name = self._gateway_name.lower().replace(' ', '_') if self._gateway_name else self._param['robot_name']  # latter option is for standalone mode
         for name in self._default_service_names:
             if (base_name == ""):
                 self._service_names[name] = '~' + self._default_service_names[name]
@@ -482,7 +486,7 @@ class RappManager(object):
         for name, rapp in avail.items():
             if name in self._preferred:
                 rapp.preferred = self._preferred[name]
-            
+
         for name, rapp in self._runnable_apps.items():
             ancestor_name = rapp.data['ancestor_name']
             avail[ancestor_name].implementations.append(name)
@@ -783,13 +787,16 @@ class RappManager(object):
         return success, message, rapp
 
     def spin(self):
+        rate = rospy.Rate(10) # 10hz
         while not rospy.is_shutdown():
             gateway_info = self._gateway_services['gateway_info'](timeout=rospy.Duration(0.3))
             if gateway_info:
                 if gateway_info.connected:
                     self._gateway_name = gateway_info.name
                     self._gateway_ip = gateway_info.ip
-                    if self._init_services():
-                        break
-            # don't need a sleep since our timeout on the service call acts like this.
+                    #if we depend on gateway we can init services now (only one time)
+                    if 0 == len(self._services) and 0 == len(self._publishers) and self._param['use_gateway_uuids']:
+                        if self._init_services():
+                            break
+            rate.sleep()
         rospy.spin()

--- a/rocon_app_manager/src/rocon_app_manager/ros_parameters.py
+++ b/rocon_app_manager/src/rocon_app_manager/ros_parameters.py
@@ -38,6 +38,9 @@ def setup_ros_parameters():
     param['app_output_to_screen'] = rocon_screen or app_manager_screen
     param['auto_rapp_installation'] = rospy.get_param('~auto_rapp_installation', False)
 
+    # to delay services creation until gateway appears (services/topics names should not change after being published)
+    param['use_gateway_uuids'] = rospy.get_param('~use_gateway_uuids',True)
+
     # Preferred rapp configuration
     param['preferred'] = rospy.get_param('~preferred',[])
 


### PR DESCRIPTION
adding parameter to delay service creation (now only once) if gateway uuid is needed.
changed standalone namespace to be robot_name (parameter) to match namespace with concert but without uuid
added delay in spin
