### PR TITLE
Rapps should get launched in the root namespace

### DIFF
--- a/rocon_app_manager/src/rocon_app_manager/ros_parameters.py
+++ b/rocon_app_manager/src/rocon_app_manager/ros_parameters.py
@@ -26,7 +26,7 @@ class StandaloneParameters:
     :ivar robot_name: also used for `rocon_uri`_ rapp compatibility checks *['robot']*
     :vartype robot_name: str
     :ivar auto_start_rapp: indicates via a `resource name`_ (e.g. gopher_rapps/delivery) a rapp to launch on startup *[None]*
-    :vartype robot_type: str
+    :vartype auto_start_rapp: str
     :ivar rapp_package_whitelist: restrict rapp search (default is the whole workspace) to these packages *[[]]*
     :vartype rapp_package_whitelist: [ str ]
     :ivar rapp_package_blacklist: if no whitelist, blacklist these packages from the search *[[]]*

--- a/rocon_app_manager/src/rocon_app_manager/utils.py
+++ b/rocon_app_manager/src/rocon_app_manager/utils.py
@@ -67,8 +67,8 @@ def _prepare_launch_text(launch_file, rapp_launch_args, public_parameters, launc
       characters or wildcards should be contained therein.
     '''
     # we used to push the include here into its own namespace (i.e. <include ns="%s" file="%s">) but it's better to let the rapp
-    # designer choose via the 'application_namespace' lauch_arg_mapping provided
-    launch_text = '<launch>\n  <include file="%s">' % (launch_file)
+    # designer choose via the 'application_namespace' lauch_arg_mapping provided, so we push it to / as an arbitrary starting point.
+    launch_text = '<launch>\n  <include file="%s" ns="/">' % (launch_file)
 
     for arg in rapp_launch_args:
         try:

--- a/rocon_apps/apps/talker/talker.launch
+++ b/rocon_apps/apps/talker/talker.launch
@@ -4,10 +4,10 @@
   <!-- rapp parameters -->
   <arg name="message" default="hello world"/>
   <arg name="frequency" default="10"/>
-  <group ns="$(arg application_namespace)">
+  <!-- <group ns="$(arg application_namespace)"> -->
     <node name="talker" pkg="rocon_apps" type="talker" required="true">
       <param name="message" value="$(arg message)"/>
       <param name="frequency" value="$(arg frequency)"/>
     </node>
-  </group>
+  <!-- </group> -->
 </launch>


### PR DESCRIPTION
Before they were launching in the `/rocon` namespace where the app manager was.

Note that we can remap things via the `application_namespace` arg in rapps themselves.
